### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Node wrapper for the Wiener Linien public transport API
 
 ## Prerequisites
 
-You will need a valid API key to access Wiener Linien's real-time data. Sign up [here](https://www.wien.gv.at/formularserver2/user/formular.aspx?pid=3b49a23de1ff43efbc45ae85faee31db&pn=B0718725a79fb40f4bb4b7e0d2d49f1d1)! 
+Since November 2019: No API-Key is needed anymore, just ignore/delete the value "SENDER=" contained in the files. Then a connection to the new data hub is immediately possible.
 
 ## Usage
 


### PR DESCRIPTION
Since November 2019: No API-Key is needed anymore, just ignore/delete the value "SENDER=" contained in the files. Then a connection to the new data hub is immediately possible.